### PR TITLE
Agent communications test fails when there are no identities

### DIFF
--- a/docs/wsl-ssh-agent-relay
+++ b/docs/wsl-ssh-agent-relay
@@ -168,7 +168,8 @@ relay() {
 
     if [[ -z "$SKIP_SSH_TEST" ]]; then
         log -n "Polling remote ssh-agent..."
-        SSH_AUTH_SOCK="${WSL_AGENT_SSH_SOCK}" ssh-add -L >/dev/null 2>&1 || die "[$?] Failure communicating with ssh-agent"
+        SSH_AUTH_SOCK="${WSL_AGENT_SSH_SOCK}" ssh-add -L >/dev/null 2>&1
+        [[ "$?" -ge 2 ]] && die "[$?] Failure communicating with ssh-agent"
         log "OK"
     fi
 


### PR DESCRIPTION
ssh-add -L returns status code 1 if the agent has no identities, which implies communications success, but currently the wsl-ssh-agent-relay script tests for status code 0 only.  From the man page, status code 2 means the agent can't be contacted, so we can treat both 0 and 1 as passing.